### PR TITLE
Fix LinkML dependency in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install LinkML toolchain
         run: |
           python -m pip install --upgrade pip
-          pip install linkml linkml-runtime linkml-renderers jsonschema jq
+          pip install linkml linkml-runtime linkml-renderer jsonschema jq
       - name: Determine version
         id: v
         run: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@ VER="${1:-dev}"
 rm -rf "$OUT"
 mkdir -p "$OUT/schema/$VER" "$OUT/schema/latest"
 
-linkml-convert --schema "$SCHEMA" --target jsonschema > "$OUT/schema/$VER/revaise.schema.json"
-linkml-convert --schema "$SCHEMA" --target context     > "$OUT/schema/$VER/context.jsonld"
+gen-json-schema "$SCHEMA" > "$OUT/schema/$VER/revaise.schema.json"
+gen-jsonld-context "$SCHEMA" > "$OUT/schema/$VER/context.jsonld"
 gen-doc --schema "$SCHEMA" --output "$OUT/docs/$VER"
 
 cp "$SCHEMA" "$OUT/schema/$VER/revaise.yaml"


### PR DESCRIPTION
## Summary
- use correct `linkml-renderer` package in CI workflow
- update build script to call `gen-json-schema` and `gen-jsonld-context`

## Testing
- `bash scripts/build.sh dev` *(fails: ValueError: Duplicate key: "role")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ccb21438832c8e04da4c38e8c3c2