### PR TITLE
Fix build script doc generation for LinkML

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ mkdir -p "$OUT/schema/$VER" "$OUT/schema/latest"
 
 gen-json-schema "$SCHEMA" > "$OUT/schema/$VER/revaise.schema.json"
 gen-jsonld-context "$SCHEMA" > "$OUT/schema/$VER/context.jsonld"
-gen-doc --schema "$SCHEMA" --output "$OUT/docs/$VER"
+gen-doc "$SCHEMA" --directory "$OUT/docs/$VER"
 
 cp "$SCHEMA" "$OUT/schema/$VER/revaise.yaml"
 


### PR DESCRIPTION
## Summary
- update build script to use current `gen-doc` CLI syntax

## Testing
- `bash scripts/build.sh dev`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb9f85e0832c93fbb397f71f6856